### PR TITLE
Add callback option, fix variable value concatenation for values with colons

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ lessc --variables-output <input.less> <output.css>
 lessc --variables-output=customFilename.json <input.less> <output.css>
 ```
 
-## Programmatic usage
+## Programmatic usage - writing to file
 ```js
 const less = require('less');
 const VariablesOutput = require('less-plugin-variables-output');
@@ -21,6 +21,23 @@ less.render(<css>, {
 	plugins: [
 		new VariablesOutput({
 			filename: 'variables.json'
+		})
+	]
+});
+```
+
+## Programmatic usage - get result as an object via callback
+```js
+const less = require('less');
+const VariablesOutput = require('less-plugin-variables-output');
+
+let variables = {};
+const varsCallback = (vars) => variables = vars;
+
+less.render(<css>, {
+	plugins: [
+		new VariablesOutput({
+			callback: varsCallback
 		})
 	]
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,20 +10,24 @@ class VariablesOutputPlugin {
 	constructor(options) {
 		this.minVersion = [2, 0, 0];
 
-		this.options = Object.assign({}, DEFAULTS, options); 
+		if (options && (
+			(options.filename && (typeof options.filename === 'string' || options.filename instanceof String)) || 
+			(options.callback && (typeof options.callback === 'function' || options.filename instanceof Function)))) {
+			this.options = options;
+		} else {
+			this.options = Object.assign({}, DEFAULTS, options); 
+		} 
 	}
 
 	install(less, pluginManager) {
-		const { filename } = this.options;
-
 		pluginManager.addPreProcessor(new PreProcessor(less));
 		pluginManager.addVisitor(new Visitor(less));
-		pluginManager.addPostProcessor(new PostProcessor(less, filename));
+		pluginManager.addPostProcessor(new PostProcessor(less, this.options));
 	}
 
 	setOptions(filename) {
 		this.options.filename = filename;
-    }
+	}
 
 	printUsage() {
 		return '--variables-output=filename.json';

--- a/lib/postProcessor.js
+++ b/lib/postProcessor.js
@@ -4,8 +4,8 @@ const mkdirp = require('mkdirp');
 const { SELECTOR } = require('./utils');
 
 class VariablesOutputPostProcessor {
-	constructor(less, filename) {
-		this.filename = filename;
+	constructor(less, options) {
+		this.options = options;
 	}
 
 	process(css) {
@@ -17,21 +17,25 @@ class VariablesOutputPostProcessor {
 		// Parse the dummy selector's contents into a regular JSON-y object
 		const json = selectorContents.split(';').reduce((memo, variable) => {
 			if (variable) {
-				const [ name, value ] = variable.split(':');
-				memo[name.trim()] = value.trim();
+				const parts = variable.split(':');
+				memo[parts[0].trim()] = parts.splice(1).join(':').trim();
 			}
 
 			return memo;
 		},
 		{});
 
-		// Pretty print the JSON
-		const contents = JSON.stringify(json, null, 4);
+		if (this.options.filename) {
+			// Pretty print the JSON
+			const contents = JSON.stringify(json, null, 4);
 
-		// Write the variables to the given filename, creating
-		// directories as we go if not present using mkdirp
-		mkdirp.sync(path.dirname(this.filename));
-		fs.writeFileSync(this.filename, contents);
+			// Write the variables to the given filename, creating
+			// directories as we go if not present using mkdirp
+			mkdirp.sync(path.dirname(this.options.filename));
+			fs.writeFileSync(this.options.filename, contents);
+		} else {
+			this.options.callback(json);
+		}
 
 		// Remove the dummy selector from the output
 		return css.slice(0, selectorStart);

--- a/test/test.js
+++ b/test/test.js
@@ -40,7 +40,10 @@ const renderLess = (contents, opts, success, done) => {
 			done(err);
 		}
 		else {
-			const output = JSON.parse(fs.readFileSync(opts.filename));
+			let output = {};
+			if (opts.filename) {
+				output = JSON.parse(fs.readFileSync(opts.filename));
+			}
 			success(output, css);
 			done();
 		}
@@ -76,6 +79,16 @@ describe(pkg.name, () => {
 			expect(fs.existsSync(qualifyPath(dir1))).to.be.true;
 			expect(fs.existsSync(qualifyPath(dir1, dir2))).to.be.true;
 			expect(fs.existsSync(filename)).to.be.true;
+		},
+		done);
+	});
+
+	it('Should invoke callback as given callback option if provided', (done) => {
+		let variables = {};
+		const callback = (vars) => variables = vars;
+
+		renderLess(LESS, { callback }, (output) => {
+			compareVariables(VARIABLES, variables);
 		},
 		done);
 	});


### PR DESCRIPTION
Add stricter options validation
Add callback option to options as an alternative way of getting the result object
Fix variable-value concatenation, if the value had a ':', then it was incorrect. For example: url('https://www.xyz.com/foo.png')