### PR TITLE
Split variable into two parts only

### DIFF
--- a/lib/postProcessor.js
+++ b/lib/postProcessor.js
@@ -17,7 +17,7 @@ class VariablesOutputPostProcessor {
 		// Parse the dummy selector's contents into a regular JSON-y object
 		const json = selectorContents.split(';').reduce((memo, variable) => {
 			if (variable) {
-				const [ name, value ] = variable.split(':');
+				const [ name, value ] = variable.split(/:(.+)/);
 				memo[name.trim()] = value.trim();
 			}
 


### PR DESCRIPTION
Split variable into two parts only, name and value, because value can contain a semicolon.

e.g. when variable is like beforecontent: valuewith:asemicolon
name = beforecontent
value = valuewith:asemicolon

e.g. 2. when variable is like gfont: Roboto+Mono:300,400
name = gfont
value = Roboto+Mono:300,400